### PR TITLE
Ignored ranks from sync QOL

### DIFF
--- a/src/main/java/net/wiseoldman/WomUtilsConfig.java
+++ b/src/main/java/net/wiseoldman/WomUtilsConfig.java
@@ -39,6 +39,14 @@ public interface WomUtilsConfig extends Config
 	)
 	String eventCodeword = "eventCodeword";
 
+	@ConfigSection(
+		name = "Not Synced Ranks",
+		description = "Ignored Ranks for WOM sync",
+		position = 5,
+		closedByDefault = true
+	)
+	String ignoredRanks = "ignoredRanks";
+	
 	@ConfigItem(
 		keyName = "playerLookupOption",
 		name = "Player option",
@@ -309,6 +317,18 @@ public interface WomUtilsConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "ignoredRanksDisplay",
+		name = "Ignored Ranks from WOM Sync",
+		description = "List of ignored ranks from WOM Sync (read only)",
+		position = 17,
+		section = ignoredRanks
+	)
+	default String ignoredRanksDisplay()
+	{
+		return "";
+	}
+
+	@ConfigItem(
 		keyName = "hiddenCompetitionIds",
 		name = "",
 		description = "",
@@ -345,4 +365,12 @@ public interface WomUtilsConfig extends Config
 		hidden = true
 	)
 	void ignoredRanks(String value);
+
+	@ConfigItem(
+		keyName = "ignoredRanksDisplay",
+		name = "",
+		description = "",
+		hidden = true
+	)
+	void ignoreRanksDisplay(String value);
 }

--- a/src/main/java/net/wiseoldman/WomUtilsPlugin.java
+++ b/src/main/java/net/wiseoldman/WomUtilsPlugin.java
@@ -5,6 +5,7 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
+import com.google.common.util.concurrent.Runnables;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -846,7 +847,10 @@ public class WomUtilsPlugin extends Plugin
 			.onClick(e -> {
 				if (!rankIsIgnored)
 				{
-					ignoredRanks.add(rankTitle.toLowerCase());
+					chatboxPanelManager.openTextMenuInput("Are you sure you want to ignore " + rankTitle + " from WOM Sync?")
+						.option("Yes", () -> ignoredRanks.add(rankTitle.toLowerCase()))
+						.option("No", Runnables.doNothing())
+						.build();
 				}
 				else
 				{

--- a/src/main/java/net/wiseoldman/WomUtilsPlugin.java
+++ b/src/main/java/net/wiseoldman/WomUtilsPlugin.java
@@ -179,9 +179,12 @@ public class WomUtilsPlugin extends Plugin
 
 	// In reality this isn't specifically the ranks widget. It's the left widget that can hold
 	// different things.
-	// TODO: Make it so the ignored ranks show up properly even if the ranks have been
-	//  chosen to show in the right widget
-	private static final int CLAN_OPTIONS_RANKS_WIDGET = 45416459;
+	// TODO make it so these widgets are recolored even if the section is updated. Either a script event or onClientTicket
+
+	private static final int CLAN_OPTIONS_RANKS_WIDGET_LEFT_TITLE = 45416455;
+	private static final int CLAN_OPTIONS_RANKS_WIDGET_LEFT = 45416459;
+	private static final int CLAN_OPTIONS_RANKS_WIDGET_RIGHT_TITLE = 45416456;
+	private static final int CLAN_OPTIONS_RANKS_WIDGET_RIGHT = 45416461;
 
 	private static final Color SUCCESS = new Color(170, 255, 40);
 	private static final Color DEFAULT_CLAN_SETTINGS_TEXT_COLOR = new Color(0xff981f);
@@ -839,8 +842,31 @@ public class WomUtilsPlugin extends Plugin
 		}
 
 		final MenuEntry entry = event.getMenuEntries()[event.getMenuEntries().length - 1];
+		Widget clanWidgetTitleLeftSide = client.getWidget(CLAN_OPTIONS_RANKS_WIDGET_LEFT_TITLE);
+		boolean leftSideRanks = false;
+		if (clanWidgetTitleLeftSide != null)
+		{
+			if (clanWidgetTitleLeftSide.getDynamicChildren().length == 5)
+			{
+				leftSideRanks = entry.getParam1() == CLAN_OPTIONS_RANKS_WIDGET_LEFT && clanWidgetTitleLeftSide.getDynamicChildren()[4].getText().equals("Rank");
+			}
+		}
+		boolean rightSideRanks = false;
+		Widget clanWidgetTitleRightSide = client.getWidget(CLAN_OPTIONS_RANKS_WIDGET_RIGHT_TITLE);
+		if (clanWidgetTitleRightSide != null)
+		{
+			if (clanWidgetTitleRightSide.getDynamicChildren().length == 5)
+			{
+				rightSideRanks = entry.getParam1() == CLAN_OPTIONS_RANKS_WIDGET_RIGHT && clanWidgetTitleRightSide.getDynamicChildren()[4].getText().equals("Rank");
+			}
+		}
 
-		if (entry.getType() != MenuAction.CC_OP || entry.getParam1() != CLAN_OPTIONS_RANKS_WIDGET)
+		if (entry.getType() != MenuAction.CC_OP)
+		{
+			return;
+		}
+
+		if (!leftSideRanks && !rightSideRanks)
 		{
 			return;
 		}
@@ -894,7 +920,13 @@ public class WomUtilsPlugin extends Plugin
 
 	private void updateIgnoredRankColors()
 	{
-		Widget parent = client.getWidget(CLAN_OPTIONS_RANKS_WIDGET);
+		updateIgnoredRankColorsByID(CLAN_OPTIONS_RANKS_WIDGET_LEFT);
+		updateIgnoredRankColorsByID(CLAN_OPTIONS_RANKS_WIDGET_RIGHT);
+	}
+
+	private void updateIgnoredRankColorsByID(int widgetID)
+	{
+		Widget parent = client.getWidget(widgetID);
 		if (parent == null)
 		{
 			return;

--- a/src/main/java/net/wiseoldman/WomUtilsPlugin.java
+++ b/src/main/java/net/wiseoldman/WomUtilsPlugin.java
@@ -12,6 +12,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
+import java.util.stream.Collectors;
 import net.runelite.api.WorldType;
 import net.runelite.api.widgets.InterfaceID;
 import net.runelite.api.widgets.WidgetUtil;
@@ -351,6 +352,17 @@ public class WomUtilsPlugin extends Plugin
 		infoBoxManager.addInfoBox(placeHolderCompetitionInfobox);
 
 		ignoredRanks = new ArrayList<>(Arrays.asList(gson.fromJson(config.ignoredRanks(), String[].class)));
+
+		String ignoreRanksDisplayText = ignoredRanks.stream()
+			.map(Object::toString)
+			.collect(Collectors.joining(", "));
+
+		// update the ignored ignoreRanksDisplayed text on load if it was modified, it's meant to be read only.
+		if (!config.ignoredRanksDisplay().equals(ignoreRanksDisplayText))
+		{
+			config.ignoreRanksDisplay(ignoreRanksDisplayText);
+		}
+
 
 		alwaysIncludedOnSync.addAll(SPLITTER.splitToList(config.alwaysIncludedOnSync()));
 
@@ -856,7 +868,11 @@ public class WomUtilsPlugin extends Plugin
 				{
 					ignoredRanks.removeIf(r -> r.equals(rankTitle.toLowerCase()));
 				}
+				// TODO only run this if the ignoreRanks did get updated
 				config.ignoredRanks(gson.toJson(ignoredRanks));
+				config.ignoreRanksDisplay(ignoredRanks.stream()
+					.map(Object::toString)
+					.collect(Collectors.joining(", ")));
 				updateIgnoredRankColors();
 			});
 	}

--- a/src/main/java/net/wiseoldman/WomUtilsPlugin.java
+++ b/src/main/java/net/wiseoldman/WomUtilsPlugin.java
@@ -860,21 +860,36 @@ public class WomUtilsPlugin extends Plugin
 				if (!rankIsIgnored)
 				{
 					chatboxPanelManager.openTextMenuInput("Are you sure you want to ignore " + rankTitle + " from WOM Sync?")
-						.option("Yes", () -> ignoredRanks.add(rankTitle.toLowerCase()))
+						.option("Yes", () -> addIgnoredRank(rankTitle))
 						.option("No", Runnables.doNothing())
 						.build();
 				}
 				else
 				{
-					ignoredRanks.removeIf(r -> r.equals(rankTitle.toLowerCase()));
+					removeIgnoreRank(rankTitle);
 				}
-				// TODO only run this if the ignoreRanks did get updated
-				config.ignoredRanks(gson.toJson(ignoredRanks));
-				config.ignoreRanksDisplay(ignoredRanks.stream()
-					.map(Object::toString)
-					.collect(Collectors.joining(", ")));
-				updateIgnoredRankColors();
 			});
+	}
+
+	private void addIgnoredRank(String rankTitle)
+	{
+		ignoredRanks.add(rankTitle.toLowerCase());
+		updateIgnoredRanks();
+	}
+
+	private void removeIgnoreRank(String rankTitle)
+	{
+		ignoredRanks.removeIf(r -> r.equals(rankTitle.toLowerCase()));
+		updateIgnoredRanks();
+	}
+
+	private void updateIgnoredRanks()
+	{
+		config.ignoredRanks(gson.toJson(ignoredRanks));
+		config.ignoreRanksDisplay(ignoredRanks.stream()
+			.map(Object::toString)
+			.collect(Collectors.joining(", ")));
+		updateIgnoredRankColors();
 	}
 
 	private void updateIgnoredRankColors()
@@ -1198,8 +1213,8 @@ public class WomUtilsPlugin extends Plugin
 
 		int membersRemoved = oldMembers.size() + membersAdded - newMembers.size();
 
-		return String.format("Synced %d clan members. %d added, %d removed, %d ranks changed.",
-			newMembers.size(), membersAdded, membersRemoved, ranksChanged);
+		return String.format("Synced WOM group members. %d added, %d removed, %d ranks changed. (%d ranks ignored).",
+			newMembers.size(), membersAdded, membersRemoved, ranksChanged, ignoredRanks.size());
 	}
 
 	private void sendResponseToChat(String message, Color color)

--- a/src/main/java/net/wiseoldman/WomUtilsPlugin.java
+++ b/src/main/java/net/wiseoldman/WomUtilsPlugin.java
@@ -1245,7 +1245,7 @@ public class WomUtilsPlugin extends Plugin
 
 		int membersRemoved = oldMembers.size() + membersAdded - newMembers.size();
 
-		return String.format("Synced WOM group members. %d added, %d removed, %d ranks changed. (%d ranks ignored).",
+		return String.format("Synced %d clan members. %d added, %d removed, %d ranks changed, %d ranks ignored.",
 			newMembers.size(), membersAdded, membersRemoved, ranksChanged, ignoredRanks.size());
 	}
 


### PR DESCRIPTION
Add a prompt to ignoring a rank from WOM sync
![image](https://github.com/wise-old-man/wiseoldman-runelite-plugin/assets/14265490/c7eb9ed0-0de2-4106-aa14-43fd69fe019a)


Add a list of titles excluded from sync as a config list, but it doesn't update anything in back end
![image](https://github.com/wise-old-man/wiseoldman-runelite-plugin/assets/14265490/f9ab395c-ad71-4e9e-97e3-c7b38691d4aa)


Closes https://github.com/wise-old-man/wiseoldman-runelite-plugin/issues/30 and https://github.com/wise-old-man/wiseoldman-runelite-plugin/issues/24