### PR TITLE
Use client thread & fix a NPE with syncButton

### DIFF
--- a/src/main/java/net/wiseoldman/WomUtilsPlugin.java
+++ b/src/main/java/net/wiseoldman/WomUtilsPlugin.java
@@ -768,19 +768,31 @@ public class WomUtilsPlugin extends Plugin
 		switch (widgetLoaded.getGroupId())
 		{
 			case CLAN_SETTINGS_MEMBERS_PAGE_WIDGET:
-				clientThread.invoke(() -> createSyncButton(CLAN_SETTINGS_MEMBERS_PAGE_WIDGET_ID));
-				if (syncButton != null) syncButton.setEnabled();
-				clientThread.invokeLater(this::updateIgnoredRankColors);
+				clientThread.invoke(() ->
+				{
+					createSyncButton(CLAN_SETTINGS_MEMBERS_PAGE_WIDGET_ID);
+					if (syncButton != null)
+					{
+						syncButton.setEnabled();
+					}
+					clientThread.invokeLater(this::updateIgnoredRankColors);
+				});
 				break;
 			case CLAN_SETTINGS_INFO_PAGE_WIDGET:
-				clientThread.invoke(() -> createSyncButton(CLAN_SETTINGS_INFO_PAGE_WIDGET_ID));
-				if (namechangesSubmitted)
+				clientThread.invoke(() ->
 				{
-					syncButton.setEnabled();
-				} else
-				{
-					clientThread.invokeLater(this::sendUpdate);
-				}
+					createSyncButton(CLAN_SETTINGS_INFO_PAGE_WIDGET_ID);
+					if (namechangesSubmitted)
+					{
+						if (syncButton != null) {
+							syncButton.setEnabled();
+						}
+					}
+					else
+					{
+						clientThread.invokeLater(this::sendUpdate);
+					}
+				});
 
 				break;
 		}
@@ -1279,7 +1291,7 @@ public class WomUtilsPlugin extends Plugin
 	{
 		if (config.syncClanButton() && config.groupId() > 0 && !Strings.isNullOrEmpty(config.verificationCode()))
 		{
-			syncButton = new SyncButton(client, womClient, chatboxPanelManager, w, groupMembers, ignoredRanks, alwaysIncludedOnSync);
+			syncButton = new SyncButton(client, clientThread, womClient, chatboxPanelManager, w, groupMembers, ignoredRanks, alwaysIncludedOnSync);
 		}
 	}
 

--- a/src/main/java/net/wiseoldman/ui/SyncButton.java
+++ b/src/main/java/net/wiseoldman/ui/SyncButton.java
@@ -1,6 +1,7 @@
 package net.wiseoldman.ui;
 
 import com.google.common.util.concurrent.Runnables;
+import net.runelite.client.callback.ClientThread;
 import net.wiseoldman.beans.GroupMembership;
 import net.wiseoldman.web.WomClient;
 import net.wiseoldman.beans.Member;
@@ -19,7 +20,8 @@ import java.util.List;
 
 public class SyncButton
 {
-    private final Client client;
+	private final Client client;
+	private final ClientThread clientThread;
     private final WomClient womClient;
     private final ChatboxPanelManager chatboxPanelManager;
     private final Widget parent;
@@ -32,11 +34,12 @@ public class SyncButton
     private Widget textWidget;
 
 
-    public SyncButton(Client client, WomClient womClient, ChatboxPanelManager chatboxPanelManager,
+    public SyncButton(Client client, ClientThread clientThread, WomClient womClient, ChatboxPanelManager chatboxPanelManager,
                       int parent, Map<String, GroupMembership> groupMembers, List<String> ignoredRanks,
                       List<String> alwaysIncludedOnSync)
     {
-        this.client = client;
+		this.client = client;
+		this.clientThread = clientThread;
         this.womClient = womClient;
         this.chatboxPanelManager = chatboxPanelManager;
         this.parent = client.getWidget(parent);
@@ -157,8 +160,8 @@ public class SyncButton
             chatboxPanelManager.openTextMenuInput(
                     "Any members not in your clan will be removed" +
                         "<br>from your WOM group. Proceed?")
-                .option("1. Yes, overwrite WOM group", this::syncMembers)
-                .option("2. No, only add new members", () -> syncMembers(false))
+                .option("1. Yes, overwrite WOM group", () -> clientThread.invoke(() -> syncMembers()))
+                .option("2. No, only add new members", () -> clientThread.invoke(() -> syncMembers(false)))
                 .option("3. Cancel", Runnables.doNothing())
                 .build();
         });


### PR DESCRIPTION
null check syncButton on CLAN_SETTINGS_INFO_PAGE_WIDGET
use clientThread for invoking

I think this is the only places where it could error, i couldn't get another `java.lang.IllegalStateException: must be called on client thread` infact i only ever got a NPE on syncButton being null. I did not get the complaint about which thread did the invoke, but only instances of clientThread.invoke are used now rather than generically doing a runnable IE `this::syncMembers` or `() -> SyncMembers(false)` so it should get less errors now. 