### PR TITLE
Change runelite version back to latest.release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.10.36-SNAPSHOT'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion


### PR DESCRIPTION
Since we need to wait for next runelite version release before our plugin changes will be merged, we can just keep it as latest.release.