### PR TITLE
Re-download group members before syncing when required

### DIFF
--- a/src/main/java/net/wiseoldman/WomUtilsPlugin.java
+++ b/src/main/java/net/wiseoldman/WomUtilsPlugin.java
@@ -264,7 +264,7 @@ public class WomUtilsPlugin extends Plugin
 
 	private Map<String, String> nameChanges = new HashMap<>();
 	private LinkedBlockingQueue<NameChangeEntry> queue = new LinkedBlockingQueue<>();
-	private Map<String, GroupMembership> groupMembers = new HashMap<>();
+	public Map<String, GroupMembership> groupMembers = new HashMap<>();
 	private List<ParticipantWithStanding> playerCompetitionsOngoing = new ArrayList<>();
 	private List<ParticipantWithCompetition> playerCompetitionsUpcoming = new ArrayList<>();
 	private List<CompetitionInfobox> competitionInfoboxes = new CopyOnWriteArrayList<>();
@@ -1303,7 +1303,7 @@ public class WomUtilsPlugin extends Plugin
 	{
 		if (config.syncClanButton() && config.groupId() > 0 && !Strings.isNullOrEmpty(config.verificationCode()))
 		{
-			syncButton = new SyncButton(client, clientThread, womClient, chatboxPanelManager, w, groupMembers, ignoredRanks, alwaysIncludedOnSync);
+			syncButton = new SyncButton(client, clientThread, this, womClient, chatboxPanelManager, w, ignoredRanks, alwaysIncludedOnSync);
 		}
 	}
 

--- a/src/main/java/net/wiseoldman/WomUtilsPlugin.java
+++ b/src/main/java/net/wiseoldman/WomUtilsPlugin.java
@@ -17,6 +17,7 @@ import net.runelite.api.IndexedObjectSet;
 import net.runelite.api.WorldType;
 import net.runelite.api.widgets.InterfaceID;
 import net.runelite.api.widgets.WidgetUtil;
+import net.runelite.client.eventbus.EventBus;
 import net.wiseoldman.beans.Competition;
 import net.wiseoldman.beans.CompetitionInfo;
 import net.wiseoldman.beans.NameChangeEntry;
@@ -201,6 +202,9 @@ public class WomUtilsPlugin extends Plugin
 
 	@Inject
 	private Client client;
+
+	@Inject
+	public EventBus eventBus;
 
 	@Inject
 	private WomUtilsConfig config;

--- a/src/main/java/net/wiseoldman/ui/SyncButton.java
+++ b/src/main/java/net/wiseoldman/ui/SyncButton.java
@@ -3,7 +3,7 @@ package net.wiseoldman.ui;
 import com.google.common.util.concurrent.Runnables;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.api.clan.ClanRank;
-import net.wiseoldman.beans.GroupMembership;
+import net.wiseoldman.WomUtilsPlugin;
 import net.wiseoldman.beans.RoleIndex;
 import net.wiseoldman.web.WomClient;
 import net.wiseoldman.beans.Member;
@@ -27,13 +27,13 @@ public class SyncButton
 {
 	private final Client client;
 	private final ClientThread clientThread;
+	private final WomUtilsPlugin plugin;
 	private final WomClient womClient;
 	private final ChatboxPanelManager chatboxPanelManager;
 	private final Widget parent;
 
 	private final List<Widget> cornersAndEdges = new ArrayList<>();
 	private final ClanSettings clanSettings;
-	private final Map<String, GroupMembership> groupMembers;
 	private final List<String> ignoredRanks;
 	private final List<String> alwaysIncludedOnSync;
 	private Widget textWidget;
@@ -51,17 +51,17 @@ public class SyncButton
 			new ClanRank(20), new ClanRank(10), new ClanRank(0)
 	);
 
-	public SyncButton(Client client, ClientThread clientThread, WomClient womClient, ChatboxPanelManager chatboxPanelManager,
-	                  int parent, Map<String, GroupMembership> groupMembers, List<String> ignoredRanks,
-	                  List<String> alwaysIncludedOnSync)
+	public SyncButton(Client client, ClientThread clientThread, WomUtilsPlugin plugin, WomClient womClient, ChatboxPanelManager chatboxPanelManager,
+					  int parent, List<String> ignoredRanks,
+					  List<String> alwaysIncludedOnSync)
 	{
 		this.client = client;
 		this.clientThread = clientThread;
+		this.plugin = plugin;
 		this.womClient = womClient;
 		this.chatboxPanelManager = chatboxPanelManager;
 		this.parent = client.getWidget(parent);
 		this.clanSettings = client.getClanSettings();
-		this.groupMembers = groupMembers;
 		this.ignoredRanks = ignoredRanks;
 		this.alwaysIncludedOnSync = alwaysIncludedOnSync;
 
@@ -136,7 +136,7 @@ public class SyncButton
 
 		if (!overwrite)
 		{
-			groupMembers.forEach((k, v) -> clanMembers.put(k, new Member(v.getPlayer().getDisplayName(), v.getRole())));
+			plugin.groupMembers.forEach((k, v) -> clanMembers.put(k, new Member(v.getPlayer().getDisplayName(), v.getRole())));
 		}
 
 		for (ClanMember clanMember : clanSettings.getMembers())

--- a/src/main/java/net/wiseoldman/ui/SyncButton.java
+++ b/src/main/java/net/wiseoldman/ui/SyncButton.java
@@ -3,8 +3,10 @@ package net.wiseoldman.ui;
 import com.google.common.util.concurrent.Runnables;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.api.clan.ClanRank;
+import net.runelite.client.eventbus.EventBus;
 import net.wiseoldman.WomUtilsPlugin;
 import net.wiseoldman.beans.RoleIndex;
+import net.wiseoldman.events.WomGroupSynced;
 import net.wiseoldman.web.WomClient;
 import net.wiseoldman.beans.Member;
 import java.util.Arrays;
@@ -39,7 +41,7 @@ public class SyncButton
 	private Widget textWidget;
 
 	private Set<RoleIndex> roleOrders = new HashSet<>();
-
+	private EventBus.Subscriber syncMembersSubscriber = null;
 
 	private final List<ClanRank> roleOrder = Arrays.asList(
 			ClanRank.OWNER, ClanRank.DEPUTY_OWNER, new ClanRank(124), new ClanRank(120),
@@ -127,13 +129,30 @@ public class SyncButton
 
 	private void syncMembers()
 	{
-		syncMembers(true);
+		syncMembers(true, false);
 	}
 
-	private void syncMembers(boolean overwrite)
+	private void syncMembers(boolean overwrite, boolean needsUpdatedGroupMembers)
 	{
 		Map<String, Member> clanMembers = new HashMap<>();
 
+		if (needsUpdatedGroupMembers) {
+			/*
+				Fixes https://github.com/wise-old-man/wiseoldman-runelite-plugin/issues/59
+				by re-downloading all group members and waiting for `plugin.groupMembers` to be updated
+				before automatically re-running this function with the up-to-date information.
+
+				It works, but could use some love.
+			 */
+			syncMembersSubscriber = plugin.eventBus.register(WomGroupSynced.class, (WomGroupSynced event) -> {
+				plugin.eventBus.unregister(syncMembersSubscriber);
+				syncMembers(overwrite, false);
+			}, 0);
+
+			womClient.importGroupMembers();
+			return;
+		}
+		
 		if (!overwrite)
 		{
 			plugin.groupMembers.forEach((k, v) -> clanMembers.put(k, new Member(v.getPlayer().getDisplayName(), v.getRole())));
@@ -185,7 +204,7 @@ public class SyncButton
 					"Any members not in your clan will be removed" +
 						"<br>from your WOM group. Proceed?")
 				.option("1. Yes, overwrite WOM group", () -> clientThread.invoke(() -> syncMembers()))
-				.option("2. No, only add new members", () -> clientThread.invoke(() -> syncMembers(false)))
+				.option("2. No, only add new members", () -> clientThread.invoke(() -> syncMembers(false, true)))
 				.option("3. Cancel", Runnables.doNothing())
 				.build();
 		});

--- a/src/main/java/net/wiseoldman/web/WomClient.java
+++ b/src/main/java/net/wiseoldman/web/WomClient.java
@@ -71,9 +71,6 @@ public class WomClient
 	@Inject
 	private ClientThread clientThread;
 
-	@Inject
-	private EventBus eventBus;
-
 	private static final Color SUCCESS = new Color(170, 255, 40);
 	private static final Color ERROR = new Color(204, 66, 66);
 
@@ -428,7 +425,7 @@ public class WomClient
 	private void postEvent(Object event)
 	{
 		// Handle callbacks on the client thread
-		clientThread.invokeLater(() -> eventBus.post(event));
+		clientThread.invokeLater(() -> plugin.eventBus.post(event));
 	}
 
 	public void fetchUpcomingPlayerCompetitions(String username)


### PR DESCRIPTION
Fixes https://github.com/wise-old-man/wiseoldman-runelite-plugin/issues/59 by re-downloading all group members and waiting for `plugin.groupMembers` to be updated
 before automatically re-running this function with the up-to-date information.

It works, but could use some love.