### PR TITLE
Add versions to user agent and include a client hint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,19 @@ dependencies {
 }
 
 group = 'net.wiseoldman'
-version = '1.3.24' // also update pluginVersion in WomClient.java
+version = '1.3.24'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
+}
+
+task createProperties(dependsOn: processResources) {
+	doLast {
+		new File("$buildDir/resources/main/version.ini").text = "pluginVersion=$project.version"
+	}
+}
+
+classes {
+	dependsOn createProperties
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 }
 
 group = 'net.wiseoldman'
-version = '1.3.24'
+version = '1.3.24' // also update pluginVersion in WomClient.java
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/net/wiseoldman/WomUtilsPlugin.java
+++ b/src/main/java/net/wiseoldman/WomUtilsPlugin.java
@@ -43,12 +43,14 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.time.temporal.ChronoUnit;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
@@ -293,10 +295,24 @@ public class WomUtilsPlugin extends Plugin
 
 	private final Map<Skill, Integer> previousSkillLevels = new EnumMap<>(Skill.class);
 
+	@Getter
+	private static String pluginVersion = "0.0.0";
+
 	static
 	{
 		WORKING_DIR = new File(RuneLite.RUNELITE_DIR, "wom-utils");
 		WORKING_DIR.mkdirs();
+
+		try (InputStream inputStream = WomUtilsPlugin.class.getResourceAsStream("/version.ini"))
+		{
+			Properties props = new Properties();
+			props.load(inputStream);
+			pluginVersion = props.getProperty("pluginVersion");
+		}
+		catch (IOException e)
+		{
+			log.error("Failed to read version.ini", e);
+		}
 	}
 
 	@Override

--- a/src/main/java/net/wiseoldman/WomUtilsPlugin.java
+++ b/src/main/java/net/wiseoldman/WomUtilsPlugin.java
@@ -318,7 +318,7 @@ public class WomUtilsPlugin extends Plugin
 	@Override
 	protected void startUp() throws Exception
 	{
-		log.info("Wise Old Man started!");
+		log.info("Wise Old Man started! (v{})", pluginVersion);
 
 		// This will work, idk why really, but ok
 		womPanel = injector.getInstance(WomPanel.class);

--- a/src/main/java/net/wiseoldman/web/WomClient.java
+++ b/src/main/java/net/wiseoldman/web/WomClient.java
@@ -86,7 +86,6 @@ public class WomClient
 	private final WomUtilsPlugin plugin;
 	private final String leagueError = " You are currently in a League world. Your group configurations might be for the main game.";
 
-	private final String userAgentClientHint;
 	private final String userAgent;
 
 	@Inject
@@ -100,9 +99,6 @@ public class WomClient
 
 		String pluginVersion = WomUtilsPlugin.getPluginVersion();
 		String runeliteVersion = RuneLiteProperties.getVersion();
-
-		userAgentClientHint = "\"WiseOldMan RuneLite Plugin\";v=\"" + pluginVersion + "\", " +
-                "\"RuneLite\";v=\"" + runeliteVersion + "\"";
 
 		userAgent = "WiseOldManRuneLitePlugin/" + pluginVersion + " " +
                 "RuneLite/" + runeliteVersion;
@@ -151,7 +147,6 @@ public class WomClient
 
 		Request.Builder requestBuilder = new Request.Builder()
 			.header("User-Agent", userAgent)
-			.header("Sec-CH-UA", userAgentClientHint)
 			.url(url);
 
 		if (httpMethod == HttpMethod.PUT)
@@ -172,7 +167,6 @@ public class WomClient
 		HttpUrl url = buildUrl(pathSegments);
 		return new Request.Builder()
 			.header("User-Agent", userAgent)
-			.header("Sec-CH-UA", userAgentClientHint)
 			.url(url)
 			.build();
 	}

--- a/src/main/java/net/wiseoldman/web/WomClient.java
+++ b/src/main/java/net/wiseoldman/web/WomClient.java
@@ -2,8 +2,6 @@ package net.wiseoldman.web;
 
 import com.google.gson.Gson;
 
-import java.io.InputStream;
-import java.util.Properties;
 import java.util.Set;
 
 import net.runelite.client.RuneLiteProperties;
@@ -100,27 +98,14 @@ public class WomClient
 
 		this.plugin = plugin;
 
-		String pluginVersion = "0.0.0";
+		String pluginVersion = WomUtilsPlugin.getPluginVersion();
 		String runeliteVersion = RuneLiteProperties.getVersion();
-
-		try (InputStream inputStream = WomUtilsPlugin.class.getResourceAsStream("/version.ini"))
-		{
-			Properties props = new Properties();
-			props.load(inputStream);
-			pluginVersion = props.getProperty("pluginVersion");
-		}
-		catch (IOException e)
-		{
-			log.error("Failed to read version.ini", e);
-		}
 
 		userAgentClientHint = "\"WiseOldMan RuneLite Plugin\";v=\"" + pluginVersion + "\", " +
                 "\"RuneLite\";v=\"" + runeliteVersion + "\"";
 
 		userAgent = "WiseOldManRuneLitePlugin/" + pluginVersion + " " +
                 "RuneLite/" + runeliteVersion;
-
-		log.info("userAgentClientHint={} userAgent={}", userAgentClientHint, userAgent);
 	}
 
 	public void submitNameChanges(NameChangeEntry[] changes)

--- a/src/main/java/net/wiseoldman/web/WomClient.java
+++ b/src/main/java/net/wiseoldman/web/WomClient.java
@@ -101,7 +101,7 @@ public class WomClient
 		String runeliteVersion = RuneLiteProperties.getVersion();
 
 		userAgent = "WiseOldManRuneLitePlugin/" + pluginVersion + " " +
-                "RuneLite/" + runeliteVersion;
+			"RuneLite/" + runeliteVersion;
 	}
 
 	public void submitNameChanges(NameChangeEntry[] changes)

--- a/src/main/java/net/wiseoldman/web/WomClient.java
+++ b/src/main/java/net/wiseoldman/web/WomClient.java
@@ -1,7 +1,10 @@
 package net.wiseoldman.web;
 
 import com.google.gson.Gson;
+
 import java.util.Set;
+
+import net.runelite.client.RuneLiteProperties;
 import net.wiseoldman.WomUtilsPlugin;
 import net.wiseoldman.beans.GroupInfoWithMemberships;
 import net.wiseoldman.beans.NameChangeEntry;
@@ -29,6 +32,7 @@ import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import javax.inject.Inject;
+
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
@@ -82,6 +86,9 @@ public class WomClient
 	private final WomUtilsPlugin plugin;
 	private final String leagueError = " You are currently in a League world. Your group configurations might be for the main game.";
 
+	private final String userAgentClientHint;
+	private final String userAgent;
+
 	@Inject
 	public WomClient(Gson gson, WomUtilsPlugin plugin)
 	{
@@ -90,6 +97,17 @@ public class WomClient
 			.create();
 
 		this.plugin = plugin;
+
+		String pluginVersion = "1.3.24";
+		String runeliteVersion = RuneLiteProperties.getVersion();
+
+		userAgentClientHint = "\"WiseOldMan RuneLite Plugin\";v=\"" + pluginVersion + "\", " +
+                "\"RuneLite\";v=\"" + runeliteVersion + "\"";
+
+		userAgent = "WiseOldManRuneLitePlugin/" + pluginVersion + " " +
+                "RuneLite/" + runeliteVersion;
+
+		log.info("userAgentClientHint={} userAgent={}", userAgentClientHint, userAgent);
 	}
 
 	public void submitNameChanges(NameChangeEntry[] changes)
@@ -134,7 +152,8 @@ public class WomClient
 		);
 
 		Request.Builder requestBuilder = new Request.Builder()
-			.header("User-Agent", "WiseOldMan RuneLite Plugin")
+			.header("User-Agent", userAgent)
+			.header("Sec-CH-UA", userAgentClientHint)
 			.url(url);
 
 		if (httpMethod == HttpMethod.PUT)
@@ -154,7 +173,8 @@ public class WomClient
 	{
 		HttpUrl url = buildUrl(pathSegments);
 		return new Request.Builder()
-			.header("User-Agent", "WiseOldMan RuneLite Plugin")
+			.header("User-Agent", userAgent)
+			.header("Sec-CH-UA", userAgentClientHint)
 			.url(url)
 			.build();
 	}

--- a/src/main/java/net/wiseoldman/web/WomClient.java
+++ b/src/main/java/net/wiseoldman/web/WomClient.java
@@ -2,6 +2,8 @@ package net.wiseoldman.web;
 
 import com.google.gson.Gson;
 
+import java.io.InputStream;
+import java.util.Properties;
 import java.util.Set;
 
 import net.runelite.client.RuneLiteProperties;
@@ -98,8 +100,19 @@ public class WomClient
 
 		this.plugin = plugin;
 
-		String pluginVersion = "1.3.24";
+		String pluginVersion = "0.0.0";
 		String runeliteVersion = RuneLiteProperties.getVersion();
+
+		try (InputStream inputStream = WomUtilsPlugin.class.getResourceAsStream("/version.ini"))
+		{
+			Properties props = new Properties();
+			props.load(inputStream);
+			pluginVersion = props.getProperty("pluginVersion");
+		}
+		catch (IOException e)
+		{
+			log.error("Failed to read version.ini", e);
+		}
 
 		userAgentClientHint = "\"WiseOldMan RuneLite Plugin\";v=\"" + pluginVersion + "\", " +
                 "\"RuneLite\";v=\"" + runeliteVersion + "\"";


### PR DESCRIPTION
Ran with:
```
userAgentClientHint: "WiseOldMan RuneLite Plugin";v="1.3.24", "RuneLite";v="1.10.43"
userAgent: WiseOldManRuneLitePlugin/1.3.24 RuneLite/1.10.43
```
^ Could probably find that in the server logs, if logs are kept.

I did deviate a bit from the format proposed in #43, which was definitely more friendly for humans to parse, but any useragent-parsing library should be able to deconstruct the ones in the pull request, which may make future changes a bit easier.

Only thing I'm really not satisfied with is having to declare the version twice... yeah I don't like that at all.