### PR TITLE
Don't send name changes that are no longer in friends/ignore list

### DIFF
--- a/src/main/java/net/wiseoldman/WomUtilsPlugin.java
+++ b/src/main/java/net/wiseoldman/WomUtilsPlugin.java
@@ -476,6 +476,14 @@ public class WomUtilsPlugin extends Plugin
 		womClient.commandLookup(player, command, chatMessage);
 	}
 
+	private boolean isValidNameChange(String prev, String curr)
+	{
+		return !(Strings.isNullOrEmpty(prev)
+			|| curr.equals(prev)
+			|| prev.startsWith("[#")
+			|| curr.startsWith("[#"));
+	}
+
 	@Subscribe
 	public void onNameableNameChanged(NameableNameChanged nameableNameChanged)
 	{
@@ -484,10 +492,7 @@ public class WomUtilsPlugin extends Plugin
 		String name = nameable.getName();
 		String prev = nameable.getPrevName();
 
-		if (Strings.isNullOrEmpty(prev)
-			|| name.equals(prev)
-			|| prev.startsWith("[#")
-			|| name.startsWith("[#"))
+		if (!isValidNameChange(prev, name))
 		{
 			return;
 		}
@@ -531,6 +536,27 @@ public class WomUtilsPlugin extends Plugin
 
 			return;
 		}
+
+		List<Nameable> friendIgnore = new ArrayList<>();
+		friendIgnore.addAll(Arrays.asList(client.getFriendContainer().getMembers()));
+		friendIgnore.addAll(Arrays.asList(client.getIgnoreContainer().getMembers()));
+
+		// List of current valid name changes in our friends/ignore list.
+		List<NameChangeEntry> validNameChanges = friendIgnore.stream()
+			.filter(nameable -> isValidNameChange(nameable.getPrevName(), nameable.getName()))
+			.map(nameable -> new NameChangeEntry(Text.toJagexName(nameable.getPrevName()), Text.toJagexName(nameable.getName())))
+			.collect(Collectors.toList());
+
+		// Remove a name change from the queue if it is no longer in our friends/ignore list at the time
+		// of submission.
+		queue.removeIf(entry -> {
+			if (!validNameChanges.contains(entry))
+			{
+				nameChanges.remove(entry.getNewName(), entry.getOldName());
+				return true;
+			}
+			return false;
+		});
 
 		womClient.submitNameChanges(queue.toArray(new NameChangeEntry[0]));
 		clientThread.invoke(queue::clear);


### PR DESCRIPTION
This PR makes it so name changes that are no longer in the friends list are not sent to wise old man. For instance, this means that when double name changes happen, the plugin won't send name changes for names that are no longer on the hiscores.