### PR TITLE
Change some config options default to false

### DIFF
--- a/src/main/java/net/wiseoldman/WomUtilsConfig.java
+++ b/src/main/java/net/wiseoldman/WomUtilsConfig.java
@@ -54,7 +54,7 @@ public interface WomUtilsConfig extends Config
 	)
 	default boolean playerLookupOption()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(
@@ -66,7 +66,7 @@ public interface WomUtilsConfig extends Config
 	)
 	default boolean menuLookupOption()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(
@@ -102,7 +102,7 @@ public interface WomUtilsConfig extends Config
 	)
 	default boolean showicons()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(
@@ -114,7 +114,7 @@ public interface WomUtilsConfig extends Config
 	)
 	default boolean showFlags()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(
@@ -126,7 +126,7 @@ public interface WomUtilsConfig extends Config
 	)
 	default boolean importGroup()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(
@@ -138,7 +138,7 @@ public interface WomUtilsConfig extends Config
 	)
 	default boolean browseGroup()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(
@@ -150,7 +150,7 @@ public interface WomUtilsConfig extends Config
 	)
 	default boolean addRemoveMember()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(
@@ -211,7 +211,7 @@ public interface WomUtilsConfig extends Config
 	)
 	default boolean competitionLoginMessage()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(


### PR DESCRIPTION
After discussions on Discord about making the plugin less cluttery, we've decided to turn defaults to off for options that add menu entries. Most people probably don't want their menus filled with new entries every time they install a new plugin, and we probably shouldn't contribute to that. Better leave it to the user to enable it themselves if they wish to have it on.

Some of these options will be removed entirely in the near future as I will keep working on the plugin. But setting them to off for now until they are eventually worked out of the plugin.