### PR TITLE
Competition panel fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 }
 
 group = 'net.wiseoldman'
-version = '1.4.0'
+version = '1.4.1'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/net/wiseoldman/WomUtilsConfig.java
+++ b/src/main/java/net/wiseoldman/WomUtilsConfig.java
@@ -324,4 +324,23 @@ public interface WomUtilsConfig extends Config
 		hidden = true
 	)
 	void ignoreRanksDisplay(String value);
+
+	@ConfigItem(
+		keyName = "competitionsOnCanvas",
+		name = "",
+		description = "",
+		hidden = true
+	)
+	default String competitionsOnCanvas()
+	{
+		return "[]";
+	}
+
+	@ConfigItem(
+		keyName = "competitionsOnCanvas",
+		name = "",
+		description = "",
+		hidden = true
+	)
+	void competitionsOnCanvas(String value);
 }

--- a/src/main/java/net/wiseoldman/WomUtilsPlugin.java
+++ b/src/main/java/net/wiseoldman/WomUtilsPlugin.java
@@ -13,11 +13,13 @@ import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
+import java.util.Set;
 import java.util.stream.Collectors;
 import net.runelite.api.IndexedObjectSet;
 import net.runelite.api.WorldType;
 import net.runelite.api.widgets.InterfaceID;
 import net.runelite.api.widgets.WidgetUtil;
+import net.wiseoldman.beans.CanvasCompetition;
 import net.wiseoldman.beans.Competition;
 import net.wiseoldman.beans.NameChangeEntry;
 import net.wiseoldman.beans.ParticipantWithStanding;
@@ -263,6 +265,7 @@ public class WomUtilsPlugin extends Plugin
 	private List<ParticipantWithStanding> playerCompetitionsOngoing = new ArrayList<>();
 	private List<ParticipantWithCompetition> playerCompetitionsUpcoming = new ArrayList<>();
 	private Map<Integer, CompetitionInfoBox> competitionInfoBoxes = new HashMap<>();
+	public List<CanvasCompetition> competitionsOnCanvas = new ArrayList<>();
 	private List<ScheduledFuture<?>> scheduledFutures = new ArrayList<>();
 	private List<String> ignoredRanks = new ArrayList<>();
 	private List<String> alwaysIncludedOnSync = new ArrayList<>();
@@ -360,6 +363,8 @@ public class WomUtilsPlugin extends Plugin
 		}
 
 		ignoredRanks = new ArrayList<>(Arrays.asList(gson.fromJson(config.ignoredRanks(), String[].class)));
+		competitionsOnCanvas = new ArrayList<>(Arrays.asList(gson.fromJson(config.competitionsOnCanvas(), CanvasCompetition[].class)));
+
 
 		String ignoreRanksDisplayText = ignoredRanks.stream()
 			.map(Object::toString)
@@ -407,6 +412,7 @@ public class WomUtilsPlugin extends Plugin
 		clientToolbar.removeNavigation(navButton);
 		womPanel.shutdown();
 		clearInfoBoxes();
+		competitionsOnCanvas.clear();
 		cancelNotifications();
 		previousSkillLevels.clear();
 		ignoredRanks.clear();
@@ -981,6 +987,7 @@ public class WomUtilsPlugin extends Plugin
 				namechangesSubmitted = false;
 				womPanel.resetCompetitionsPanel();
 				womPanel.resetGroupFilter();
+				clearInfoBoxes();
 			case HOPPING:
 				Player local = client.getLocalPlayer();
 				if (local == null)
@@ -1153,9 +1160,23 @@ public class WomUtilsPlugin extends Plugin
 
 	public void addInfoBox(CompetitionCardPanel p)
 	{
+		int competitionId = p.getCompetition().getId();
+		if (hasInfoBox(competitionId))
+		{
+			return;
+		}
+
 		CompetitionInfoBox infoBox = new CompetitionInfoBox(p, this);
-		competitionInfoBoxes.put(p.getCompetition().getId(), infoBox);
+		competitionInfoBoxes.put(competitionId, infoBox);
 		infoBoxManager.addInfoBox(infoBox);
+
+		if (competitionsOnCanvas.stream().map(CanvasCompetition::getId).collect(Collectors.toSet()).contains(competitionId))
+		{
+			return;
+		}
+
+		competitionsOnCanvas.add(new CanvasCompetition(competitionId, p.getCompetition().isActive()));
+		config.competitionsOnCanvas(gson.toJson(competitionsOnCanvas));
 	}
 
 	public void removeInfoBox(CompetitionCardPanel p)
@@ -1163,6 +1184,15 @@ public class WomUtilsPlugin extends Plugin
 		int id = p.getCompetition().getId();
 		infoBoxManager.removeIf(e -> e instanceof CompetitionInfoBox && ((CompetitionInfoBox) e).getCompetition().getId() == id);
 		competitionInfoBoxes.remove(id);
+
+		competitionsOnCanvas.removeIf(c -> c.getId() == id);
+		config.competitionsOnCanvas(gson.toJson(competitionsOnCanvas));
+	}
+
+	public void clearOldCanvasCompetitions(Set<Integer> competitionIds, boolean ongoing)
+	{
+		competitionsOnCanvas.removeIf(onCanvas -> onCanvas.isOngoing() == ongoing && !competitionIds.contains(onCanvas.getId()));
+		config.competitionsOnCanvas(gson.toJson(competitionsOnCanvas));
 	}
 
 	public boolean hasInfoBox(int id)

--- a/src/main/java/net/wiseoldman/WomUtilsPlugin.java
+++ b/src/main/java/net/wiseoldman/WomUtilsPlugin.java
@@ -27,6 +27,7 @@ import net.wiseoldman.events.WomGroupMemberAdded;
 import net.wiseoldman.events.WomGroupMemberRemoved;
 import net.wiseoldman.events.WomGroupSynced;
 import net.wiseoldman.events.WomOngoingPlayerCompetitionsFetched;
+import net.wiseoldman.events.WomRequestFailed;
 import net.wiseoldman.events.WomUpcomingPlayerCompetitionsFetched;
 import net.wiseoldman.panel.CompetitionCardPanel;
 import net.wiseoldman.panel.NameAutocompleter;
@@ -36,6 +37,7 @@ import net.wiseoldman.ui.CompetitionInfoBox;
 import net.wiseoldman.ui.SyncButton;
 import net.wiseoldman.ui.WomIconHandler;
 import net.wiseoldman.util.DelayedAction;
+import net.wiseoldman.web.WomRequestType;
 import net.wiseoldman.web.WomClient;
 import net.wiseoldman.web.WomCommand;
 import java.awt.Color;
@@ -1138,6 +1140,15 @@ public class WomUtilsPlugin extends Plugin
 		updateScheduledNotifications();
 		womPanel.addUpcomingCompetitions(playerCompetitionsUpcoming);
 		womPanel.addGroupFilters(playerCompetitionsUpcoming.stream().map(ParticipantWithCompetition::getCompetition).toArray(Competition[]::new));
+	}
+
+	@Subscribe
+	public void onWomRequestFailed(WomRequestFailed event)
+	{
+		if (event.getType() == WomRequestType.COMPETITIONS_ONGOING || event.getType() == WomRequestType.COMPETITIONS_UPCOMING)
+		{
+			womPanel.displayCompetitionFetchError(event.getType(), event.getUsername());
+		}
 	}
 
 	public void addInfoBox(CompetitionCardPanel p)

--- a/src/main/java/net/wiseoldman/beans/CanvasCompetition.java
+++ b/src/main/java/net/wiseoldman/beans/CanvasCompetition.java
@@ -1,0 +1,10 @@
+package net.wiseoldman.beans;
+
+import lombok.Value;
+
+@Value
+public class CanvasCompetition
+{
+	int id;
+	boolean isOngoing;
+}

--- a/src/main/java/net/wiseoldman/events/WomRequestFailed.java
+++ b/src/main/java/net/wiseoldman/events/WomRequestFailed.java
@@ -1,0 +1,11 @@
+package net.wiseoldman.events;
+
+import lombok.Value;
+import net.wiseoldman.web.WomRequestType;
+
+@Value
+public class WomRequestFailed
+{
+	String username;
+	WomRequestType type;
+}

--- a/src/main/java/net/wiseoldman/panel/WomPanel.java
+++ b/src/main/java/net/wiseoldman/panel/WomPanel.java
@@ -2,6 +2,8 @@ package net.wiseoldman.panel;
 
 import com.google.common.base.Strings;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import net.runelite.api.WorldType;
 import net.runelite.client.ui.components.PluginErrorPanel;
 import net.wiseoldman.WomUtilsConfig;
@@ -474,11 +476,20 @@ public class WomPanel extends PluginPanel
 		JPanel ongoingCompetitions = new JPanel();
 		ongoingCompetitions.setLayout(new BoxLayout(ongoingCompetitions, BoxLayout.Y_AXIS));
 
+		// Remove any competition from canvas list that are no longer in the newly fetched competitions list
+		Set<Integer> currentOngoing = competitions.stream().map(ParticipantWithStanding::getCompetitionId).collect(Collectors.toSet());
+		plugin.clearOldCanvasCompetitions(currentOngoing, true);
+
 		for (ParticipantWithStanding c : competitions)
 		{
 			CompetitionCardPanel competitionPanel = new CompetitionCardPanel(client, plugin, c);
 			competitionCardPanels.add(competitionPanel);
 			ongoingCompetitions.add(competitionPanel);
+
+			if (plugin.competitionsOnCanvas.stream().anyMatch(cc -> cc.getId() == c.getCompetitionId()))
+			{
+				plugin.addInfoBox(competitionPanel);
+			}
 		}
 
 		if (competitionsErrorPanel.isVisible() && !competitionCardPanels.isEmpty())
@@ -496,12 +507,22 @@ public class WomPanel extends PluginPanel
 		JPanel upcomingCompetitions = new JPanel();
 		upcomingCompetitions.setLayout(new BoxLayout(upcomingCompetitions, BoxLayout.Y_AXIS));
 
+		// Remove any competition from canvas list that are no longer in the newly fetched competitions list
+		Set<Integer> currentUpcoming = competitions.stream().map(ParticipantWithCompetition::getCompetitionId).collect(Collectors.toSet());
+		plugin.clearOldCanvasCompetitions(currentUpcoming, false);
+
 		for (ParticipantWithCompetition c : competitions)
 		{
 			CompetitionCardPanel competitionPanel = new CompetitionCardPanel(client, plugin, c);
 			competitionCardPanels.add(competitionPanel);
 			upcomingCompetitions.add(competitionPanel);
+
+			if (plugin.competitionsOnCanvas.stream().anyMatch(cc -> cc.getId() == c.getCompetitionId()))
+			{
+				plugin.addInfoBox(competitionPanel);
+			}
 		}
+
 
 		if (competitionsErrorPanel.isVisible() && !competitionCardPanels.isEmpty())
 		{

--- a/src/main/java/net/wiseoldman/web/WomRequestType.java
+++ b/src/main/java/net/wiseoldman/web/WomRequestType.java
@@ -1,0 +1,17 @@
+package net.wiseoldman.web;
+
+import lombok.Getter;
+
+@Getter
+public enum WomRequestType
+{
+	COMPETITIONS_ONGOING("ongoing"),
+	COMPETITIONS_UPCOMING("upcoming");
+
+	final String name;
+
+	WomRequestType(String name)
+	{
+		this.name = name;
+	}
+}


### PR DESCRIPTION
- Show an error alongside a retry button when fetching competitions fails.
![image](https://github.com/user-attachments/assets/84823705-78c9-401c-bcf0-f388f449aa04)
- Competitions added to the canvas are saved between sessions so you only need to add a competition to teh canvas once until it ends insead of every time you restart the client.