### PR TITLE
Load the correct runecrafting metric icon

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 }
 
 group = 'net.wiseoldman'
-version = '1.4.1'
+version = '1.4.2'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/net/wiseoldman/beans/Metric.java
+++ b/src/main/java/net/wiseoldman/beans/Metric.java
@@ -251,7 +251,8 @@ public enum Metric
 			directory = "/skill_icons_small/";
 		}
 
-		return ImageUtil.loadImageResource(WomUtilsPlugin.class, directory + name().toLowerCase() + ".png");
+		String fileName = name().equalsIgnoreCase("runecrafting") ? "runecraft" : name().toLowerCase();
+		return ImageUtil.loadImageResource(WomUtilsPlugin.class, directory + fileName + ".png");
 	}
 
 	public String getName()


### PR DESCRIPTION
Runecraft.ing metric name strikes again.
When I removed the icon metrics we used for the competitions, I forgot to fix the Runecrafting -> Runecraft mapping.