### PR TITLE
bugfix: if metric was null, all competitions would fail to load in si.. 

### DIFF
--- a/src/main/java/net/wiseoldman/WomUtilsPlugin.java
+++ b/src/main/java/net/wiseoldman/WomUtilsPlugin.java
@@ -1106,7 +1106,12 @@ public class WomUtilsPlugin extends Plugin
 	@Subscribe
 	public void onWomOngoingPlayerCompetitionsFetched(WomOngoingPlayerCompetitionsFetched event)
 	{
-		playerCompetitionsOngoing = Arrays.asList(event.getCompetitions());
+		// Filter out competitions with null metrics
+		ParticipantWithStanding[] filteredCompetitions = Arrays.stream(event.getCompetitions())
+				.filter(pws -> pws.getCompetition().getMetric() != null)
+				.toArray(ParticipantWithStanding[]::new);
+
+		playerCompetitionsOngoing = Arrays.asList(filteredCompetitions);
 		log.debug("Fetched {} ongoing competitions for player {}", event.getCompetitions().length, event.getUsername());
 		for (ParticipantWithStanding pws : playerCompetitionsOngoing)
 		{
@@ -1124,7 +1129,12 @@ public class WomUtilsPlugin extends Plugin
 	@Subscribe
 	public void onWomUpcomingPlayerCompetitionsFetched(WomUpcomingPlayerCompetitionsFetched event)
 	{
-		playerCompetitionsUpcoming = Arrays.asList(event.getCompetitions());
+		// Filter out competitions with null metrics
+		ParticipantWithCompetition[] filteredCompetitions = Arrays.stream(event.getCompetitions())
+				.filter(pwc -> pwc.getCompetition().getMetric() != null)
+				.toArray(ParticipantWithCompetition[]::new);
+
+		playerCompetitionsUpcoming = Arrays.asList(filteredCompetitions);
 		log.debug("Fetched {} upcoming competitions for player {}", event.getCompetitions().length, event.getUsername());
 		updateScheduledNotifications();
 		womPanel.addUpcomingCompetitions(playerCompetitionsUpcoming);

--- a/src/main/java/net/wiseoldman/WomUtilsPlugin.java
+++ b/src/main/java/net/wiseoldman/WomUtilsPlugin.java
@@ -1107,11 +1107,10 @@ public class WomUtilsPlugin extends Plugin
 	public void onWomOngoingPlayerCompetitionsFetched(WomOngoingPlayerCompetitionsFetched event)
 	{
 		// Filter out competitions with null metrics
-		ParticipantWithStanding[] filteredCompetitions = Arrays.stream(event.getCompetitions())
+		playerCompetitionsOngoing = Arrays.stream(event.getCompetitions())
 				.filter(pws -> pws.getCompetition().getMetric() != null)
-				.toArray(ParticipantWithStanding[]::new);
+				.collect(Collectors.toList());
 
-		playerCompetitionsOngoing = Arrays.asList(filteredCompetitions);
 		log.debug("Fetched {} ongoing competitions for player {}", event.getCompetitions().length, event.getUsername());
 		for (ParticipantWithStanding pws : playerCompetitionsOngoing)
 		{
@@ -1130,11 +1129,10 @@ public class WomUtilsPlugin extends Plugin
 	public void onWomUpcomingPlayerCompetitionsFetched(WomUpcomingPlayerCompetitionsFetched event)
 	{
 		// Filter out competitions with null metrics
-		ParticipantWithCompetition[] filteredCompetitions = Arrays.stream(event.getCompetitions())
+		playerCompetitionsUpcoming = Arrays.stream(event.getCompetitions())
 				.filter(pwc -> pwc.getCompetition().getMetric() != null)
-				.toArray(ParticipantWithCompetition[]::new);
+				.collect(Collectors.toList());
 
-		playerCompetitionsUpcoming = Arrays.asList(filteredCompetitions);
 		log.debug("Fetched {} upcoming competitions for player {}", event.getCompetitions().length, event.getUsername());
 		updateScheduledNotifications();
 		womPanel.addUpcomingCompetitions(playerCompetitionsUpcoming);


### PR DESCRIPTION
…depanel ui

- fix by filtering out competitions where metrics == null

Addresses #74 