### PR TITLE
Add option to automatically add competitions to canvas

### DIFF
--- a/src/main/java/net/wiseoldman/WomUtilsConfig.java
+++ b/src/main/java/net/wiseoldman/WomUtilsConfig.java
@@ -9,6 +9,15 @@ import net.runelite.client.config.ConfigSection;
 @ConfigGroup(WomUtilsPlugin.CONFIG_GROUP)
 public interface WomUtilsConfig extends Config
 {
+
+	enum CompetitionsToAddToCanvas
+	{
+		NONE,
+		UPCOMING,
+		ONGOING,
+		BOTH
+	}
+
 	@ConfigSection(
 		name = "Group",
 		description = "The group configurations",
@@ -218,12 +227,24 @@ public interface WomUtilsConfig extends Config
 		keyName = "sendCompetitionNotification",
 		name = "Competition Notifications",
 		description = "Sends notifications at start and end times for competitions",
-		position = 5,
+		position = 2,
 		section = competitionConfig
 	)
 	default boolean sendCompetitionNotification()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+		keyName = "addCompetitionsToCanvas",
+		name = "Auto add to canvas",
+		description = "Automatically add competitions to canvas",
+		position = 3,
+		section = competitionConfig
+	)
+	default CompetitionsToAddToCanvas addCompetitionsToCanvas()
+	{
+		return CompetitionsToAddToCanvas.NONE;
 	}
 
 	@ConfigItem(

--- a/src/main/java/net/wiseoldman/panel/WomPanel.java
+++ b/src/main/java/net/wiseoldman/panel/WomPanel.java
@@ -492,7 +492,9 @@ public class WomPanel extends PluginPanel
 			competitionCardPanels.add(competitionPanel);
 			ongoingCompetitions.add(competitionPanel);
 
-			if (plugin.competitionsOnCanvas.stream().anyMatch(cc -> cc.getId() == c.getCompetitionId()))
+			if (plugin.competitionsOnCanvas.stream().anyMatch(cc -> cc.getId() == c.getCompetitionId()) ||
+				config.addCompetitionsToCanvas().equals(WomUtilsConfig.CompetitionsToAddToCanvas.ONGOING) ||
+				config.addCompetitionsToCanvas().equals(WomUtilsConfig.CompetitionsToAddToCanvas.BOTH))
 			{
 				plugin.addInfoBox(competitionPanel);
 			}
@@ -523,7 +525,9 @@ public class WomPanel extends PluginPanel
 			competitionCardPanels.add(competitionPanel);
 			upcomingCompetitions.add(competitionPanel);
 
-			if (plugin.competitionsOnCanvas.stream().anyMatch(cc -> cc.getId() == c.getCompetitionId()))
+			if (plugin.competitionsOnCanvas.stream().anyMatch(cc -> cc.getId() == c.getCompetitionId()) ||
+				config.addCompetitionsToCanvas().equals(WomUtilsConfig.CompetitionsToAddToCanvas.UPCOMING) ||
+				config.addCompetitionsToCanvas().equals(WomUtilsConfig.CompetitionsToAddToCanvas.BOTH))
 			{
 				plugin.addInfoBox(competitionPanel);
 			}


### PR DESCRIPTION
Add an option to automatically add competitions to canvas when competitions are fetched on log in or on plugin start up. Defaults to none. Can choose between none, upcoming, ongoing or both.

This was a feature before I moved the competitions to the side panel that a few people have expressed they want back.
![image](https://github.com/user-attachments/assets/6ce5ce1d-613e-421c-8a43-6ebb29792658)
