### PR TITLE
Only compare member lists if group id has been configured

### DIFF
--- a/src/main/java/net/wiseoldman/WomUtilsPlugin.java
+++ b/src/main/java/net/wiseoldman/WomUtilsPlugin.java
@@ -1038,11 +1038,11 @@ public class WomUtilsPlugin extends Plugin
 			if (tickCounter >= 5 && !comparedClanMembers)
 			{
 				ClanSettings clanSettings = client.getClanSettings();
-				if (clanSettings != null)
+				if (clanSettings != null && config.groupId() > 0)
 				{
 					compareClanMembersList(clanSettings);
-					comparedClanMembers = true;
 				}
+				comparedClanMembers = true;
 			}
 			else
 			{


### PR DESCRIPTION
Only check if wise old man group and in-game clan are out of sync if the user has configured a group.