### PR TITLE
Resend group sync request when opted out players are involved

### DIFF
--- a/src/main/java/net/wiseoldman/beans/WomStatus.java
+++ b/src/main/java/net/wiseoldman/beans/WomStatus.java
@@ -5,5 +5,6 @@ import lombok.Value;
 @Value
 public class WomStatus
 {
-    String message;
+	String message;
+	String[] data;
 }


### PR DESCRIPTION
When players who have opted out, from being added to groups/being tracked, are in a clan that is being synced an error is returned from the API which breaks the sync feature. This PR makes it so opted out players are excluded from the sync.