### PR TITLE
Only compare members if verification code is also configured

### DIFF
--- a/src/main/java/net/wiseoldman/WomUtilsPlugin.java
+++ b/src/main/java/net/wiseoldman/WomUtilsPlugin.java
@@ -957,7 +957,7 @@ public class WomUtilsPlugin extends Plugin
 			if (tickCounter >= 5 && !comparedClanMembers)
 			{
 				ClanSettings clanSettings = client.getClanSettings();
-				if (clanSettings != null && config.groupId() > 0)
+				if (clanSettings != null && config.groupId() > 0 && !Strings.isNullOrEmpty(config.verificationCode()))
 				{
 					compareClanMembersList(clanSettings);
 				}


### PR DESCRIPTION
Only compare the clan and group members if the verification code has also been configured.
I should have added this from the beginning. 